### PR TITLE
Created larger click spots for secondary navbar. 

### DIFF
--- a/app.js
+++ b/app.js
@@ -53,7 +53,7 @@ navbarSecondaryMobile.querySelectorAll('a')
 })
 
 
-navbarSecondaryDesktop.querySelectorAll('a')
+navbarSecondaryDesktop.querySelectorAll('#js__navbar-secondary--desktop li')  //Changed the selector from 'a' to '#js__navbar-secondary--desktop li' to select each li inside the desktop secondary navbar
 .forEach((e) => {
   e.addEventListener('click', () => {
     let sectionName = e.innerHTML.toLowerCase();


### PR DESCRIPTION
Updated the querySelectorAll for navbarSecondaryDesktop to be the entire `li` within the containing `div` not limited to the `a` only. This increased the clickable area resulting in a slightly better user experience.

To ensure proper scoping only `li` within `#js__navbar-secondary--desktop` were selected. This results in only the three intended `li` being affected by this change. 

My testing didn't result in any adverse effects to this change.